### PR TITLE
docs: update readme input formats to json and semantic kernel yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,21 +380,96 @@ LLMs excel at extracting meaning from messy text, logs, documents, and mixed-for
 }
 ```
 
-### YAML Input
+### Microsoft Semantic Kernel YAML Templates
+
+The toolkit supports Microsoft Semantic Kernel YAML templates with embedded schemas and execution settings. See [examples/05-templates/](examples/05-templates/) for comprehensive examples.
+
+**Simple Question Template** (`template.yaml`):
 
 ```yaml
-messages:
-  - role: system
-    content: "You are a helpful assistant."
-  - role: user
-    content: "Your task description here"
-context:
-  session_id: "optional-session-id"
-  metadata:
-    any: "additional context"
+name: SimpleQuestion
+description: Simple semantic kernel template for asking questions
+template_format: semantic-kernel
+template: |
+  You are a helpful {{$role}} assistant. 
+  Please answer this question: {{$question}}
+  
+  Provide a clear and concise response.
+
+input_variables:
+  - name: role
+    description: The role of the assistant (e.g., technical, customer service)
+    default: "technical"
+    is_required: false
+  - name: question  
+    description: The question to be answered
+    is_required: true
+
+execution_settings:
+  azure_openai:
+    temperature: 0.7
+    max_tokens: 500
+    top_p: 1.0
 ```
 
-### Template-Based Input
+**Template Variables** (`template-vars.yaml`):
+
+```yaml
+role: expert DevOps engineer
+question: What is the difference between continuous integration and continuous deployment?
+```
+
+**Structured Analysis Template** with embedded JSON schema:
+
+```yaml
+name: StructuredAnalysis
+description: SK template with embedded JSON schema for structured output
+template_format: semantic-kernel
+template: |
+  Analyze the following text and provide a structured response: {{$text_to_analyze}}
+
+input_variables:
+  - name: text_to_analyze
+    description: The text content to analyze
+    is_required: true
+
+execution_settings:
+  azure_openai:
+    model_id: gpt-4.1-stable
+    temperature: 0.3
+    max_tokens: 800
+    response_format:
+      type: json_schema
+      json_schema:
+        name: analysis_result
+        schema:
+          type: object
+          properties:
+            sentiment:
+              type: string
+              enum: ["positive", "negative", "neutral"]
+              description: Overall sentiment of the text
+            confidence:
+              type: number
+              minimum: 0.0
+              maximum: 1.0
+              description: Confidence score for the sentiment analysis
+            key_themes:
+              type: array
+              items:
+                type: string
+              description: Main themes identified in the text
+            summary:
+              type: string
+              description: Brief summary of the text
+            word_count:
+              type: integer
+              description: Approximate word count
+          required: ["sentiment", "confidence", "summary"]
+          additionalProperties: false
+```
+
+### Template-Based Input (Handlebars & Jinja2)
 
 **Handlebars Template** (`template.hbs`):
 


### PR DESCRIPTION
# 🚀 Pull Request Checklist

Please review and check each item before submitting your PR:

- [x] 📝 **Descriptive title** (use [Conventional Commits](https://www.conventionalcommits.org/))
- [x] 📄 **Clear description** of changes and rationale
- [x] 📚 **Documentation updated** (if applicable)
- [x] 💬 **Comments updated** (keep all, fix typos, add context for AI if needed)
- [x] 🛡️ **No breaking changes** (or clearly documented)

Autimatically validated for you, plese see the pipeline status:

- [ ] ✅ **All CI checks passing** (locally run `./scripts/check.sh`)
- [ ] 🧪 **Tests added/updated** for new functionality (check coverage)
- [ ] 🧠 **Code follows style guide** (formatting, linting, type checks)

---

Thank you for contributing to the AI-First DevOps Toolkit! 🚀

---

## Changes

This PR updates the `README.md` to reflect current input format support.

### Rationale

The "Input Formats" section previously mentioned an outdated YAML format for LLM messages. This update aligns the documentation with the toolkit's current capabilities, specifically by showcasing Microsoft Semantic Kernel YAML templates.

### What's Changed

- Replaced the outdated YAML input example with comprehensive examples of **Microsoft Semantic Kernel YAML templates**.
- Added examples for:
    - A simple question template.
    - How to provide template variables.
    - A structured analysis template with an embedded JSON schema.
- Included a link to the `examples/05-templates/` directory for more detailed examples.
- Ensured all other valid information (JSON, Handlebars, Jinja2 template support) remains untouched.

This change improves the accuracy and clarity of the documentation for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-e531a7f9-d089-4cd8-92b5-0511ea7765ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e531a7f9-d089-4cd8-92b5-0511ea7765ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

